### PR TITLE
Fix: scroll for large tables

### DIFF
--- a/src-ui/src/app/components/manage/management-list/management-list.component.scss
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.scss
@@ -1,6 +1,16 @@
+// horizontal scrolling for large table contents
+.card.border {
+    overflow-x: auto;
+}
+
 // hide caret on mobile dropdown
 .d-block.d-sm-none .dropdown-toggle::after {
     display: none;
+}
+
+// dropdown menu can flow outside the tables bounding box
+.dropdown-menu.show {
+    position: fixed !important;
 }
 
 tbody tr:last-child td {


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->
When displaying a table whose content is so long that it does not fit into the space of the table, the contents will extend beyond the border on mobile deviceds. This applies to the management tables of correspondents, tags, document types and storage paths.
I added a horizontal scroll for the table that shows up when the content is too long. Now there are no more unsightly protruding contents.

Before:
![Bildschirmfoto vom 2024-04-21 19-22-17](https://github.com/DlieBG/paperless-ngx/assets/27806856/cf39c3f5-ccde-41d0-9742-7f41dff4b3d9)

After:
[Bildschirmaufzeichnung vom 21.04.2024, 19:22:53.webm](https://github.com/DlieBG/paperless-ngx/assets/27806856/812bd3ee-e67f-463c-957a-7a3186d1cef4)


## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [x] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
